### PR TITLE
Add fix for special characters when converting to JSON in old powershell

### DIFF
--- a/Build-Task.ps1
+++ b/Build-Task.ps1
@@ -206,15 +206,19 @@ try {
                     $RepositoryUrl = "https://github.com/$($Package.Name).git"
                     $RepositoryDestination = "$PackageTemp/$($Package.Name.Split("/")[1])"
                     Write-Host "[GitHub] Processing $($RepositoryUrl)"
-                    & git.exe clone $RepositoryUrl $RepositoryDestination | Out-Null
+                    & git.exe clone `
+                        --depth 1 `
+                        --no-checkout `
+                        $RepositoryUrl `
+                        $RepositoryDestination
 
                     if ($Package.Copy) {
                         $Package.Copy | ForEach-Object {
+                            & git.exe -C $RepositoryDestination checkout HEAD "$_/*"
                             Write-Host "[GitHub] Copying dependency $_ to $($Package.Path)"
                             Copy-Item -Path $RepositoryDestination/$_ -Destination $ResolvedPackagePath -Recurse -Force
                         }
                     }
-
                     break
                 }
                 'Local' {

--- a/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/configuration/Build-ConfigurationEntity.ps1
+++ b/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/configuration/Build-ConfigurationEntity.ps1
@@ -21,6 +21,13 @@ function Build-ConfigurationEntity {
         $Schema = Expand-Schema -PropertyObject $SchemaObject.Properties
         $Configuration = ($Schema | ConvertTo-Json -Depth 10 -Compress)
 
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
+            $Configuration = [Regex]::Replace($Configuration,
+                "\\u(?<Value>[a-zA-Z0-9]{4})", {
+                    param($m) ([char]([int]::Parse($m.Groups['Value'].Value,
+                                [System.Globalization.NumberStyles]::HexNumber))).ToString() } )
+        }
+
         Write-Output $Configuration
     }
     catch {

--- a/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/Get-TableEntity.ps1
+++ b/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/Get-TableEntity.ps1
@@ -19,7 +19,9 @@ function Get-TableEntity {
         }
         elseif ($Global:IsAzureRm) {
             $TableOperation = [Microsoft.WindowsAzure.Storage.Table.TableOperation]::Retrieve($PartitionKey, $RowKey)
-
+        }
+        else {
+            throw "Couldn't find Global Azure module setting $($MyInvocation.ScriptLineNumber) $($MyInvocation.ScriptName)"
         }
         $Entity = $StorageTable.CloudTable.Execute($TableOperation, $null, $null)
 

--- a/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/New-TableEntity.ps1
+++ b/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/New-TableEntity.ps1
@@ -14,19 +14,17 @@ function New-TableEntity {
 
         if ($Global:IsAz) {
             $Entity = [Microsoft.Azure.Cosmos.Table.DynamicTableEntity]::new($PartitionKey, $RowKey)
-        }
-        elseif ($Global:IsAzureRm) {
-            $Entity = New-Object -TypeName Microsoft.WindowsAzure.Storage.Table.DynamicTableEntity -ArgumentList $PartitionKey, $RowKey
-        }
-
-        $Entity.Properties.Add("Data", $Configuration)
-        if ($Global:IsAz) {
+            $Entity.Properties.Add("Data", $Configuration)
             $null = $StorageTable.CloudTable.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($Entity))
         }
         elseif ($Global:IsAzureRm) {
+            $Entity = [Microsoft.WindowsAzure.Storage.Table.DynamicTableEntity]::new($PartitionKey, $RowKey)
+            $Entity.Properties.Add("Data", $Configuration)
             $null = $StorageTable.CloudTable.Execute([Microsoft.WindowsAzure.Storage.Table.TableOperation]::Insert($Entity))
         }
-
+        else {
+            throw "Couldn't find Global Azure module setting $($MyInvocation.ScriptLineNumber) $($MyInvocation.ScriptName)"
+        }
     }
     catch {
         Write-Error -Message "$_" -ErrorAction Stop

--- a/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/Set-TableEntity.ps1
+++ b/tasks/EnvironmentConfiguration/task/ps_modules/Handlers/private/storage/Set-TableEntity.ps1
@@ -16,6 +16,9 @@ function Set-TableEntity {
         elseif ($Global:IsAzureRm) {
             $null = $StorageTable.CloudTable.Execute([Microsoft.WindowsAzure.Storage.Table.TableOperation]::InsertOrReplace($Entity))
         }
+        else {
+            throw "Couldn't find Global Azure module setting $($MyInvocation.ScriptLineNumber) $($MyInvocation.ScriptName)"
+        }
 
     }
     catch {

--- a/tasks/EnvironmentConfiguration/tests/Start-MockTaskRunner.ps1
+++ b/tasks/EnvironmentConfiguration/tests/Start-MockTaskRunner.ps1
@@ -1,22 +1,30 @@
-$ENV:SYSTEM_CULTURE = "en_US"
-$VerbosePreference = "Continue"
-$Debugpreference = "Continue"
+$TestRunner = Start-Job -ScriptBlock {
+    $ENV:SYSTEM_CULTURE = "en_US"
+    $VerbosePreference = "Continue"
+    $Debugpreference = "Continue"
 
-Import-Module -Name $PSScriptRoot/../task/ps_modules/VstsTaskSdk -Force
-Import-Module -Name $PSScriptRoot/modules/UnitTest.Helpers.psm1 -Force
-Import-Module -Name $PSScriptRoot/../task/InitializationHelpers.psm1 -Force
+    Import-Module -Name $using:PSScriptRoot/../task/ps_modules/VstsTaskSdk -Force
+    Import-Module -Name $using:PSScriptRoot/modules/UnitTest.Helpers.psm1 -Force
+    Import-Module -Name $using:PSScriptRoot/../task/InitializationHelpers.psm1 -Force
 
-try {
-    Set-MockEnvironment
+    try {
+        Set-MockEnvironment
 
-    $SourcePath = "$PSScriptRoot/resource"
-    $TargetFilename = "*.schema.json"
-    $TableName = "configuration"
-    $StorageAccount = "helloitscraigstr"
-    $EnvironmentName = "dev"
-    . $PSScriptRoot/../task/Invoke-Task.ps1
+        $SourcePath = "$using:PSScriptRoot/resource"
+        $TargetFilename = "*.schema.json"
+        $TableName = "configuration"
+        $StorageAccount = "testconversion41"
+        $EnvironmentName = "dev"
+        . $using:PSScriptRoot/../task/Invoke-Task.ps1
 
+    }
+    finally {
+        Clear-MockEnvironment
+    }
 }
-finally {
-    Clear-MockEnvironment
-}
+# Wait for default input
+Wait-Job $TestRunner
+Receive-Job $TestRunner
+
+Wait-Job $TestRunner
+Receive-Job $TestRunner

--- a/tasks/EnvironmentConfiguration/tests/modules/UnitTest.Helpers.psm1
+++ b/tasks/EnvironmentConfiguration/tests/modules/UnitTest.Helpers.psm1
@@ -18,7 +18,7 @@ function Set-MockEnvironment {
     $ENV:PaymentsObjectArray = @"
     [{"Enabled": true, "aString": "string"}]
 "@
-
+    $ENV:GoogleHeaderUrl = "'https://www.googletagmanager.com/gtm.js?id='wrappedinquotes'&gtm_auth=someauth&gtm_preview=env-7&gtm_cookies_win=x'"
 }
 
 function Clear-MockEnvironment {
@@ -34,7 +34,8 @@ function Clear-MockEnvironment {
         "ENV:PaymentsEnabled",
         "ENV:PaymentsInt",
         "ENV:PaymentsNumber",
-        "ENV:PaymentsArray"
+        "ENV:PaymentsArray",
+        "ENV:GoogleHeaderUrl"
     )
 }
 

--- a/tasks/EnvironmentConfiguration/tests/resource/SFA.DAS.Test.Valid.json
+++ b/tasks/EnvironmentConfiguration/tests/resource/SFA.DAS.Test.Valid.json
@@ -17,5 +17,6 @@
       "Enabled": true,
       "aString": "string"
     }
-  ]
+  ],
+  "GoogleHeaderUrl": "'https://www.googletagmanager.com/gtm.js?id='wrappedinquotes'&gtm_auth=someauth&gtm_preview=env-7&gtm_cookies_win=x'"
 }

--- a/tasks/EnvironmentConfiguration/tests/resource/SFA.DAS.Test.schema.json
+++ b/tasks/EnvironmentConfiguration/tests/resource/SFA.DAS.Test.schema.json
@@ -75,6 +75,10 @@
       },
       "minItems": 0,
       "environmentVariable": "PaymentsObjectArray"
+    },
+    "GoogleHeaderUrl": {
+      "type": "string",
+      "environmentVariable": "GoogleHeaderUrl"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Use the following solution to convert unicode characters back when using ConvertTo-Json in Powershell 5.1: 
https://stackoverflow.com/questions/47779157/convertto-json-with-special-characters-with-or-without-unscape-result-is-wrong/47779605#47779605

Also, run the MockTaskRunner as a background process to avoid dll locks on rebuild and fix module detection when running locally