### PR TITLE
Add a mock task runner

### DIFF
--- a/tasks/DependencyCheck/index.ts
+++ b/tasks/DependencyCheck/index.ts
@@ -16,12 +16,11 @@ async function run(): Promise<void> {
     tl.debug(`Setting resource path to ${taskManifestPath}`);
     tl.setResourcePath(taskManifestPath);
 
-    // process.env's added for local debugging only in absense of a proper TaskRunner. TO BE REMOVED!
-    const workspaceId: string = tl.getInput('workspaceId') || process.env.workspaceId as string;
-    const sharedKey: string = tl.getInput('sharedKey') || process.env.sharedKey as string;
-    const selfHostedDatabase: boolean = tl.getBoolInput('selfHostedDatabase') || (process.env.selfHostedDatabase === 'true');
-    const storageAccountName: string = tl.getInput('storageAccountName', (selfHostedDatabase && (tl.getVariable('System.Debug') === 'true'))) || process.env.storageAccountName as string;
-    const scanPath: string = tl.getInput('scanPath') || process.env.scanPath as string;
+    const workspaceId: string = tl.getInput('workspaceId', true) as string;
+    const sharedKey: string = tl.getInput('sharedKey', true) as string;
+    const selfHostedDatabase: boolean = tl.getBoolInput('selfHostedDatabase', true);
+    const storageAccountName: string = tl.getInput('storageAccountName', (selfHostedDatabase)) as string;
+    const scanPath: string = tl.getInput('scanPath', true) as string;
 
     const la: ILogAnalyticsClient = new LogAnalyticsClient(
       workspaceId,

--- a/tasks/DependencyCheck/package-lock.json
+++ b/tasks/DependencyCheck/package-lock.json
@@ -3414,6 +3414,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",

--- a/tasks/DependencyCheck/package.json
+++ b/tasks/DependencyCheck/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha tests/_suite.js",
+    "test": "npm run build && node ./tests/TaskRunner.js",
     "lint": "eslint . --ext .ts",
     "build": "tsc -p ./",
     "start": "npm run build && node index.js",
@@ -20,7 +20,8 @@
     "csvtojson": "^2.0.10",
     "node-emoji": "^1.10.0",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.8"
+    "request-promise-native": "^1.0.8",
+    "typescript": "^3.7.5"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",

--- a/tasks/DependencyCheck/package.json
+++ b/tasks/DependencyCheck/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && node ./tests/TaskRunner.js",
+    "test": "npm run build && node  -r dotenv/config  ./tests/TaskRunner.js",
     "lint": "eslint . --ext .ts",
     "build": "tsc -p ./",
     "start": "npm run build && node index.js",

--- a/tasks/DependencyCheck/tests/TaskRunner.ts
+++ b/tasks/DependencyCheck/tests/TaskRunner.ts
@@ -1,0 +1,40 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const inputs = [
+  'workspaceId',
+  'sharedKey',
+  'selfHostedDatabase',
+  'storageAccountName',
+  'scanPath',
+];
+
+const taskPath = path.join(__dirname, '..', 'index.js');
+const dependencyCheckDataPath = `${__dirname}/dependency-check-cli/data`;
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const missingVars: string[] = [];
+
+tmr.setAnswers(
+  {
+    checkPath: { [dependencyCheckDataPath]: true },
+    rmRF: { [dependencyCheckDataPath]: { success: true } },
+  },
+);
+
+inputs.forEach((i) => {
+  console.log(` -> Setting mock task input ${i}`);
+  const val = process.env[i];
+
+  if (!val || val === undefined) {
+    console.log('here');
+    missingVars.push(i);
+  } else {
+    tmr.setInput(i, val);
+  }
+});
+
+if (missingVars.length > 0) {
+  console.error(`Could not find required inputs for task to complete, check your env for [${missingVars.join(',')}]`);
+} else {
+  tmr.run();
+}

--- a/tasks/DependencyCheck/tests/TaskRunner.ts
+++ b/tasks/DependencyCheck/tests/TaskRunner.ts
@@ -10,7 +10,8 @@ const inputs = [
 ];
 
 const taskPath = path.join(__dirname, '..', 'index.js');
-const dependencyCheckDataPath = `${__dirname}/dependency-check-cli/data`;
+const dependencyCheckDataPath = path.join(__dirname, '..', 'dependency-check-cli', 'data');
+console.log(dependencyCheckDataPath);
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 const missingVars: string[] = [];
 
@@ -26,7 +27,6 @@ inputs.forEach((i) => {
   const val = process.env[i];
 
   if (!val || val === undefined) {
-    console.log('here');
     missingVars.push(i);
   } else {
     tmr.setInput(i, val);

--- a/tasks/DependencyCheck/utility.ts
+++ b/tasks/DependencyCheck/utility.ts
@@ -11,6 +11,7 @@ export function cleanDependencyCheckData(): void {
     tl.checkPath(path, 'Dependency check cli data folder');
     tl.rmRF(path);
   } catch (e) {
+    console.debug(`An error was caugh during cleanup ${e}`);
     console.warn(`Data path did not exist. The task will attempt to create it at: ${path}`);
   }
 

--- a/tasks/DependencyCheck/utility.ts
+++ b/tasks/DependencyCheck/utility.ts
@@ -4,18 +4,19 @@ import * as cp from 'child_process';
 import emoji = require('node-emoji');
 import tl = require('azure-pipelines-task-lib/task');
 import http = require('https');
+import path = require('path');
 
 export function cleanDependencyCheckData(): void {
-  const path = `${__dirname}/dependency-check-cli/data`;
+  const p = path.join(__dirname, 'dependency-check-cli', 'data');
   try {
-    tl.checkPath(path, 'Dependency check cli data folder');
-    tl.rmRF(path);
+    tl.checkPath(p, 'Dependency check cli data folder');
+    tl.rmRF(p);
   } catch (e) {
-    console.debug(`An error was caugh during cleanup ${e}`);
-    console.warn(`Data path did not exist. The task will attempt to create it at: ${path}`);
+    tl.debug(`An error was caugh during cleanup ${e}`);
+    tl.warning(`Data path did not exist. The task will attempt to create it at: ${p}`);
   }
 
-  tl.mkdirP(path);
+  tl.mkdirP(p);
 }
 
 export async function getVulnData(vulnUrl: string, filePath: string): Promise<void> {


### PR DESCRIPTION
This PR adds a mock task runner to help with local execution.

- The runner can be launched with `npm test`
- `tl.checkPath` and `tl.rmRF` are mocked to always return `true`
- Also have fixed the way we build paths in utility.ts