### PR TITLE
DependencyCheck: Automatic task versioning (Major version increment to 1.X.X)

### DIFF
--- a/Build-Task.ps1
+++ b/Build-Task.ps1
@@ -40,7 +40,7 @@
 
     .NOTES
     Requirements:
-    The following applications must be installed an available in your PATH
+    The following applications must be installed and available in your PATH
     - git
     - tfx-cli
 #>

--- a/Set-Version.ps1
+++ b/Set-Version.ps1
@@ -51,7 +51,7 @@ function Set-Version {
 }
 
 try {
-    if ($ENV:BUILD_BUILDNUMBER) {
+    if ($ENV:GITVERSION_MAJORMINORPATCH) {
         $ResolvedTaskRoot = (Resolve-Path -Path "$TaskRoot").Path
         Set-Version -TaskRoot $ResolvedTaskRoot
     }

--- a/Set-Version.ps1
+++ b/Set-Version.ps1
@@ -1,0 +1,61 @@
+<#
+    .SYNOPSIS
+    Set task version at build time
+
+    .DESCRIPTION
+    Set task version at build time
+
+    .PARAMETER TaskRoot
+    The root of the task to be built
+
+    .EXAMPLE
+    ./Set-Version.ps1 -TaskRoot ./MyTask
+#>
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $true)]
+    [System.Io.FileInfo]$TaskRoot
+)
+
+# Default error action to stop
+$ErrorActionPreference = "Stop"
+
+function Set-Version {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [String]$TaskRoot
+    )
+    try {
+        $Manifest = "$TaskRoot/vss-extension.json"
+        $Task = "$TaskRoot/task/task.json"
+
+        $NewVersion = $ENV:GITVERSION_MAJORMINORPATCH
+        [Version]$Version = $NewVersion
+
+        $ManifestObject = Get-Content -Path $Manifest -Raw | ConvertFrom-Json
+        $TaskObject = Get-Content -Path $Task -Raw | ConvertFrom-Json
+
+        $ManifestObject.Version = $Version.ToString()
+
+        $TaskObject.Version.Major = $Version.Major
+        $TaskObject.Version.Minor = $Version.Minor
+        $TaskObject.Version.Patch = $Version.Build
+        Write-Verbose -Message "Version set to $NewVersion"
+
+        $ManifestObject | ConvertTo-Json -Depth 10 | Set-Content -Path $Manifest
+        $TaskObject | ConvertTo-Json -Depth 10 | Set-Content -Path $Task
+    }
+    catch {
+        Write-Error -Message "Failed to update task version number: $_" -ErrorAction Stop
+    }
+}
+
+try {
+    if ($ENV:BUILD_BUILDNUMBER) {
+        $ResolvedTaskRoot = (Resolve-Path -Path "$TaskRoot").Path
+        Set-Version -TaskRoot $ResolvedTaskRoot
+    }
+}
+catch {
+    $PSCmdlet.ThrowTerminatingError($_)
+}

--- a/tasks/DependencyCheck/GitVersion.yml
+++ b/tasks/DependencyCheck/GitVersion.yml
@@ -1,0 +1,1 @@
+mode: Mainline

--- a/tasks/DependencyCheck/azure-pipelines.yml
+++ b/tasks/DependencyCheck/azure-pipelines.yml
@@ -6,6 +6,7 @@ trigger:
   paths:
     include:
       - tasks/DependencyCheck/*
+      - Set-Version.ps1
 
 pr: none
 

--- a/tasks/DependencyCheck/azure-pipelines.yml
+++ b/tasks/DependencyCheck/azure-pipelines.yml
@@ -1,5 +1,3 @@
-name: "0.1.$(rev:r)"
-
 trigger:
   batch: true
   branches:
@@ -18,6 +16,15 @@ pool:
   name: 'DAS - Continuous Integration'
 
 steps:
+- task: UseGitVersion@5
+  inputs:
+    versionSpec: 5.x
+    useConfigFile: true
+    configFilePath: '$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/GitVersion.yml'
+- powershell: |
+    ./Set-Version.ps1 -TaskRoot $(System.DefaultWorkingDirectory)/tasks/DependencyCheck
+  displayName: "Set Task Version"
+  workingDirectory: $(System.DefaultWorkingDirectory)
 - task: Npm@1
   displayName: 'npm install --production'
   inputs:
@@ -52,7 +59,7 @@ steps:
     outputPath: '$(System.DefaultWorkingDirectory)/release/bin'
 - task: ms-devlabs.vsts-developer-tools-build-tasks.publish-extension-build-task.PublishAzureDevOpsExtension@2
   displayName: 'Publish Extension'
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   inputs:
     connectedServiceName: 'Visual Studio Marketplace (VSTS)'
     fileType: vsix

--- a/tasks/DependencyCheck/task/task.json
+++ b/tasks/DependencyCheck/task/task.json
@@ -9,7 +9,7 @@
   "author": "esfadevops",
   "version": {
     "Major": 0,
-    "Minor": 3,
+    "Minor": 0,
     "Patch": 0
   },
   "instanceNameFormat": "Dependency Check",

--- a/tasks/DependencyCheck/vss-extension.json
+++ b/tasks/DependencyCheck/vss-extension.json
@@ -9,7 +9,7 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "OWASP Dependency Check task for Azure Pipelines",
+  "description": "Dependency Check task for Azure Pipelines",
   "categories": [
     "Azure Pipelines"
   ],

--- a/tasks/DependencyCheck/vss-extension.json
+++ b/tasks/DependencyCheck/vss-extension.json
@@ -9,7 +9,7 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "Dependency Check task for Azure Pipelines",
+  "description": "OWASP Dependency Check task for Azure Pipelines",
   "categories": [
     "Azure Pipelines"
   ],

--- a/tasks/DependencyCheck/vss-extension.json
+++ b/tasks/DependencyCheck/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "DependencyCheck",
   "name": "Dependency Check",
-  "version": "0.3.0",
+  "version": "Task version set in azure-pipelines.yml",
   "publisher": "esfadevops",
   "targets": [
     {

--- a/tasks/EnvironmentConfiguration/azure-pipelines.yml
+++ b/tasks/EnvironmentConfiguration/azure-pipelines.yml
@@ -8,6 +8,8 @@ trigger:
   paths:
     include:
       - /tasks/EnvironmentConfiguration
+      - azure-pipelines.template.yml
+      - Build-Task.ps1
 
 pr: none
 

--- a/tasks/EnvironmentConfiguration/task/task.json
+++ b/tasks/EnvironmentConfiguration/task/task.json
@@ -10,9 +10,9 @@
     "Release"
   ],
   "version": {
-    "Major": 3,
+    "Major": 0,
     "Minor": 0,
-    "Patch": 253
+    "Patch": 0
   },
   "groups": [
     {

--- a/tasks/EnvironmentConfiguration/vss-extension.json
+++ b/tasks/EnvironmentConfiguration/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "GenerateEnvironmentConfiguration",
   "name": "Generate Environment Configuration",
-  "version": "3.0.253",
+  "version": "Task version set in azure-pipelines.yml",
   "publisher": "esfadevops",
   "targets": [
     {


### PR DESCRIPTION
DependencyCheck:
- Added UseGitversion task
- Created Set-Version.ps1 based from Set-Version function in Build-Task.ps1
- In Set-Version.ps1, used GitVersion's build number for Azure DevOps task version
- Corrected condition for task publish to require master and pipeline succeeding

EnvironmentConfiguration, DependencyCheck:
- Updated build path triggers
- Set placeholder task versions referencing that they are set in azure-pipelines.yml