### PR TITLE
Task to now use automatically updated versioned vulnerability files +semver:major

### DIFF
--- a/tasks/DependencyCheck/azure-pipelines.yml
+++ b/tasks/DependencyCheck/azure-pipelines.yml
@@ -39,8 +39,9 @@ steps:
     command: custom
     verbose: false
     customCommand: 'install -g typescript'
-- powershell: Remove-Item "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task/tests" -Recurse
-  displayName: 'PowerShell Script: Remove tests folder'
+- powershell: |
+   Copy-Item "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task/tests" -Destination "$(System.DefaultWorkingDirectory)/temp-tests" -Recurse
+   Remove-Item "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task/tests" -Recurse
 - script: tsc
   workingDirectory: $(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task
   displayName: 'Command Line Script: tsc'
@@ -58,6 +59,60 @@ steps:
   inputs:
     rootFolder: '$(System.DefaultWorkingDirectory)/tasks/DependencyCheck'
     outputPath: '$(System.DefaultWorkingDirectory)/release/bin'
+- task: DownloadGitHubRelease@0
+  displayName: 'Download GitHub Release'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  inputs:
+    connection: 'GitHub (SFA)'
+    userRepository: 'SkillsFundingAgency/das-platform-automation'
+    defaultVersionType: specificTag
+    version: 3.0.0
+- task: AzurePowerShell@4
+  displayName: 'Azure PowerShell script: $(System.ArtifactsDirectory)/New-StorageAccountSASToken.ps1'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  inputs:
+    azureSubscription: Enterprise
+    ScriptPath: '$(System.ArtifactsDirectory)/New-StorageAccountSASToken.ps1'
+    ScriptArguments: '-ResourceGroup "$(SharedEnvResourceGroup)" -StorageAccount "$(SharedStorageAccountName)" -Service "$(StorageAccountService)" -ResourceType "$(StorageAccountResourceType)" -Permissions "$(StorageAccountPermissions)" -ExpiryInMinutes "$(SasUriExpiryInMinutes)" -OutputVariable "WriteStorageAccountContainerSasUri"'
+    azurePowerShellVersion: LatestVersion
+- powershell: |
+   Copy-Item "$(System.DefaultWorkingDirectory)/temp-tests" -Destination "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task/tests" -Recurse
+   $Path = "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task"
+   $Value = @"
+   enableVulnerabilityFilesMaintenance=true
+   writeStorageAccountContainerSasUri=https://$($ENV:SharedStorageAccountName).$($ENV:StorageAccountService).core.windows.net/$($ENV:StorageAccountContainerName)$($ENV:WRITE_STORAGE_ACCOUNT_CONTAINER_SAS_URI)
+   workspaceId=placeholder
+   sharedKey=placeholder
+   enableSelfHostedVulnerabilityFiles=placeholder
+   readStorageAccountContainerSasUri=placeholder
+   scanPath=placeholder
+   excludedScanPathPatterns=placeholder
+   "@
+   New-Item -Path $Path -Name ".env" -Value $Value
+   Get-Content -Path "$($Path)/.env"
+   Rename-Item "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task" "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/$($ENV:GITVERSION_MAJORMINORPATCH)"
+  env:
+    WRITE_STORAGE_ACCOUNT_CONTAINER_SAS_URI: $(WriteStorageAccountContainerSasUri)
+  displayName: 'PowerShell Script: Restore tests folder, add a .env file for npm test, renamed task folder to GITVERSION_MAJORMINORPATCH'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+- task: Npm@1
+  displayName: 'npm install'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  inputs:
+    workingDir: '$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/$(GITVERSION.MAJORMINORPATCH)'
+    verbose: false
+- script: tsc
+  workingDirectory: $(System.DefaultWorkingDirectory)/tasks/DependencyCheck/$(GITVERSION.MAJORMINORPATCH)
+  displayName: 'Command Line Script: tsc'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+- task: Npm@1
+  displayName: 'npm test to create the new versioned vulnerability files on the storage account'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  inputs:
+    command: custom
+    workingDir: '$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/$(GITVERSION.MAJORMINORPATCH)'
+    verbose: false
+    customCommand: 'test'
 - task: ms-devlabs.vsts-developer-tools-build-tasks.publish-extension-build-task.PublishAzureDevOpsExtension@2
   displayName: 'Publish Extension'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/tasks/DependencyCheck/azure-pipelines.yml
+++ b/tasks/DependencyCheck/azure-pipelines.yml
@@ -71,7 +71,7 @@ steps:
   displayName: 'Azure PowerShell script: $(System.ArtifactsDirectory)/New-StorageAccountSASToken.ps1'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   inputs:
-    azureSubscription: Enterprise
+    azureSubscription: SFA-DIG-Prod-ARM
     ScriptPath: '$(System.ArtifactsDirectory)/New-StorageAccountSASToken.ps1'
     ScriptArguments: '-ResourceGroup "$(SharedEnvResourceGroup)" -StorageAccount "$(SharedStorageAccountName)" -Service "$(StorageAccountService)" -ResourceType "$(StorageAccountResourceType)" -Permissions "$(StorageAccountPermissions)" -ExpiryInMinutes "$(SasUriExpiryInMinutes)" -OutputVariable "WriteStorageAccountContainerSasUri"'
     azurePowerShellVersion: LatestVersion

--- a/tasks/DependencyCheck/task/index.ts
+++ b/tasks/DependencyCheck/task/index.ts
@@ -1,11 +1,14 @@
 import csv from 'csvtojson';
 import { spawnSync } from 'child_process';
 import { LogAnalyticsClient, ILogAnalyticsClient } from './log-analytics';
-import { getVulnData, owaspCheck, cleanDependencyCheckData } from './utility';
+import { downloadVulnData, UploadVulnData, owaspCheck, cleanDependencyCheckData } from './utility';
 
 import emoji = require('node-emoji');
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
+
+const taskVersion = path.basename(__dirname);
+tl.debug(`DependencyCheck task version: ${taskVersion}`);
 
 const logType = 'DependencyCheck';
 const csvFilePath = `${__dirname}/dependency-check-report.csv`;
@@ -17,65 +20,73 @@ async function run(): Promise<void> {
     tl.debug(`Setting resource path to ${taskManifestPath}`);
     tl.setResourcePath(taskManifestPath);
 
-    const workspaceId: string = tl.getInput('workspaceId', true) as string;
-    const sharedKey: string = tl.getInput('sharedKey', true) as string;
-    const enableSelfHostedDatabase: boolean = tl.getBoolInput('enableSelfHostedDatabase', true);
-    const databaseEndpoint: string = tl.getInput('databaseEndpoint', (enableSelfHostedDatabase)) as string;
-    const scanPath: string = tl.getInput('scanPath', true) as string;
-    const excludedScanPathPatterns: string = tl.getInput('excludedScanPathPatterns', true) as string;
-
-    let repositoryName = (tl.getVariable('Build.Repository.Name'))?.split('/')[1];
-    let branchName = tl.getVariable('Build.SourceBranchName');
-    let buildName = tl.getVariable('Build.DefinitionName');
-    let buildNumber = tl.getVariable('Build.BuildNumber');
-    let commitId = tl.getVariable('Build.SourceVersion');
-
-    const la: ILogAnalyticsClient = new LogAnalyticsClient(
-      workspaceId,
-      sharedKey,
-    );
+    const enableVulnerabilityFilesMaintenance: boolean = tl.getBoolInput('enableVulnerabilityFilesMaintenance', true);
+    const writeStorageAccountContainerSasUri: string = tl.getInput('writeStorageAccountContainerSasUri', false) as string;
+    const workspaceId: string = tl.getInput('workspaceId', false) as string;
+    const sharedKey: string = tl.getInput('sharedKey', false) as string;
+    const enableSelfHostedVulnerabilityFiles: boolean = tl.getBoolInput('enableSelfHostedVulnerabilityFiles', false);
+    const readStorageAccountContainerSasUri: string = tl.getInput('readStorageAccountContainerSasUri', false) as string;
+    const scanPath: string = tl.getInput('scanPath', false) as string;
+    const excludedScanPathPatterns: string = tl.getInput('excludedScanPathPatterns', false) as string;
 
     const scriptBasePath = `${__dirname}/dependency-check-cli/bin/dependency-check`;
     const scriptFullPath = process.platform === 'win32' ? `${scriptBasePath}.bat` : `${scriptBasePath}.sh`;
+
     tl.debug(`Dependency check script path set to ${scriptFullPath}`);
 
     if (!(process.platform === 'win32')) {
       spawnSync('chmod', ['+x', scriptFullPath])
     }
 
-    if (enableSelfHostedDatabase) {
-      const trimmedDatabaseEndpoint = databaseEndpoint.replace(/\/$/, '');
-      cleanDependencyCheckData();
-      await getVulnData(trimmedDatabaseEndpoint, 'odc.mv.db', `${__dirname}/dependency-check-cli/data/odc.mv.db`);
-      await getVulnData(trimmedDatabaseEndpoint, 'jsrepository.json', `${__dirname}/dependency-check-cli/data/jsrepository.json`);
-    }
+    if (!enableVulnerabilityFilesMaintenance) {
+      let repositoryName = (tl.getVariable('Build.Repository.Name'))?.split('/')[1];
+      let branchName = tl.getVariable('Build.SourceBranchName');
+      let buildName = tl.getVariable('Build.DefinitionName');
+      let buildNumber = tl.getVariable('Build.BuildNumber');
+      let commitId = tl.getVariable('Build.SourceVersion');
 
-    await owaspCheck(scriptFullPath, scanPath, excludedScanPathPatterns, csvFilePath, enableSelfHostedDatabase);
+      const la: ILogAnalyticsClient = new LogAnalyticsClient(
+        workspaceId,
+        sharedKey,
+      );
 
-    const payload = await csv()
-      .fromFile(csvFilePath)
-      .subscribe((jsonObj: any) => {
-        return new Promise((resolve, reject) => {
-          jsonObj.RepositoryName = repositoryName;
-          jsonObj.BranchName = branchName;
-          jsonObj.BuildName = buildName;
-          jsonObj.BuildNumber = buildNumber;
-          jsonObj.CommitId = commitId;
-          resolve();
+      if (enableSelfHostedVulnerabilityFiles) {
+        await downloadVulnData(readStorageAccountContainerSasUri, `${__dirname}/dependency-check-cli/data/odc.mv.db`, taskVersion);
+        await downloadVulnData(readStorageAccountContainerSasUri, `${__dirname}/dependency-check-cli/data/jsrepository.json`, taskVersion);
+      }
+
+      await owaspCheck(scriptFullPath, scanPath, excludedScanPathPatterns, csvFilePath, enableSelfHostedVulnerabilityFiles);
+
+      const payload = await csv()
+        .fromFile(csvFilePath)
+        .subscribe((jsonObj: any) => {
+          return new Promise((resolve, reject) => {
+            jsonObj.RepositoryName = repositoryName;
+            jsonObj.BranchName = branchName;
+            jsonObj.BuildName = buildName;
+            jsonObj.BuildNumber = buildNumber;
+            jsonObj.CommitId = commitId;
+            resolve();
+          })
         })
-      })
 
-    if (payload.length > 0) {
-      await la.sendLogAnalyticsData(
-        JSON.stringify(payload), logType, new Date().toISOString(),
-      ).then((() => {
-        const vuln = payload.length > 1 ? 'vulnerabilities' : 'vulnerability';
-        tl.warning(`${emoji.get('pensive')}  A total of ${payload.length} ${vuln} were found in this project.`);
-      })).catch(((e) => {
-        tl.setResult(tl.TaskResult.Failed, e);
-      }));
-    } else {
-      console.log(`${emoji.get('slightly_smiling_face')}  Good news, there are no vulnerabilities to report!`);
+      if (payload.length > 0) {
+        await la.sendLogAnalyticsData(
+          JSON.stringify(payload), logType, new Date().toISOString(),
+        ).then((() => {
+          const vuln = payload.length > 1 ? 'vulnerabilities' : 'vulnerability';
+          tl.warning(`${emoji.get('pensive')}  A total of ${payload.length} ${vuln} were found in this project.`);
+        })).catch(((e) => {
+          tl.setResult(tl.TaskResult.Failed, e);
+        }));
+      } else {
+        console.log(`${emoji.get('slightly_smiling_face')}  Good news, there are no vulnerabilities to report!`);
+      }
+    }
+    else {
+      await owaspCheck(scriptFullPath, scriptFullPath, excludedScanPathPatterns, csvFilePath, false);
+      await UploadVulnData(writeStorageAccountContainerSasUri, `${__dirname}/dependency-check-cli/data/odc.mv.db`, taskVersion);
+      await UploadVulnData(writeStorageAccountContainerSasUri, `${__dirname}/dependency-check-cli/data/jsrepository.json`, taskVersion);
     }
 
     cleanDependencyCheckData();

--- a/tasks/DependencyCheck/task/package-lock.json
+++ b/tasks/DependencyCheck/task/package-lock.json
@@ -4,6 +4,133 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.2.tgz",
+      "integrity": "sha512-IUbP/f3v96dpHgXUwsAjUwDzjlUjawyUhWhGKKB6Qxy+iqppC/pVBPyc6kdpyTe7H30HN+4H3f0lar7Wp9Hx6A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.1.2.tgz",
+      "integrity": "sha512-xeZpTs6caBIrRipqZs70jgrA+mAFxII5XrBzbOCELPs18n4QWfchB20F94ITAk3GuFVDaSBsOhVL3GP1J+ncGg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.1.2",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.6.1",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "cross-env": "^6.0.3",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.2.tgz",
+      "integrity": "sha512-Yr0JD7GKryOmbcb5wHCQoQ4KCcH5QJWRNorofid+UvudLaxnbCfvKh/cUfQsGUqRjO9L/Bw4X7FP824DcHdMxw==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.1.tgz",
+      "integrity": "sha512-hqEJBEGKan4YdOaL9ZG/GRG6PXaFd/Wb3SSjQW4LWotZzgl6xqG00h6wmkrpd2NNkbBkD1erLHBO3lPHApv+iQ==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.8.tgz",
+      "integrity": "sha512-ZKUpCd7Dlyfn7bdc+/zC/sf0aRIaNQMDuSj2RhYRFe3p70hVAnYGp3TX4cnG2yoEALp/LTj/XnZGQ8Xzf6Ja/Q==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-g2qLDgvmhyIxR3JVS8N67CyIOeFRKQlX/llxYJQr1OSGQqM3HTpVP8MjmjcEKbL/OIt2N9C9UFaNQuKOw1laOA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.1.2.tgz",
+      "integrity": "sha512-PCHgG4r3xLt5FaFj+uiMqrRpuzD3TD17cvxCeA1JKK2bJEf8b07H3QRLQVf0DM1MmvYY8FgQagkWZTp+jr9yew==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.6.1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -42,6 +169,24 @@
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
       }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.6.1.tgz",
+      "integrity": "sha512-wpufGZa7tTxw7eAsjXJtiyIQ42IWQdX9iUQp7ACJcKo1hCtuhLU+K2Nv1U6oRwT1oAlZTE6m4CgWKZBhOiau3Q==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.6.1"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.6.1.tgz",
+      "integrity": "sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ=="
     },
     "@types/caseless": {
       "version": "0.12.2",
@@ -100,6 +245,27 @@
       "resolved": "https://registry.npmjs.org/@types/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -140,6 +306,14 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.18.0",
@@ -339,9 +513,9 @@
       }
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asap": {
@@ -524,20 +698,28 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+      "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.2.tgz",
-      "integrity": "sha512-QfFrU0CIw2oltVvpndW32kuJ/9YOJwUnmWrjlXt1nnJZHCaS9i6bfOpg9R4Lw8aZjStkJWM+jc0cdXjWBgVJSw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "caseless": {
@@ -691,6 +873,52 @@
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1300,6 +1528,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+    },
     "execa": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
@@ -1701,6 +1934,11 @@
         }
       }
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -1849,8 +2087,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -1994,6 +2231,12 @@
         }
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -2086,22 +2329,24 @@
       "dev": true
     },
     "meow": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.0.1.tgz",
-      "integrity": "sha512-kxGTFgT/b7/oSRSQsJ0qsT5IMU+bgZ1eAdSA3kIV7onkW0QWo/hL5RbGlMfvBjHJKPE1LaPX0kdecYFiqYWjUw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.1.1",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
         "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.0.0",
-        "minimist-options": "^4.0.1",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
         "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.0",
+        "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.8.1",
-        "yargs-parser": "^16.1.0"
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
       },
       "dependencies": {
         "find-up": {
@@ -2124,9 +2369,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -2194,6 +2439,14 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
           }
         }
       }
@@ -2218,9 +2471,9 @@
       "dev": true
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimatch": {
@@ -2238,13 +2491,22 @@
       "dev": true
     },
     "minimist-options": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
-      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        }
       }
     },
     "mkdirp": {
@@ -2298,6 +2560,11 @@
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2596,6 +2863,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -2897,8 +3169,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.7.1",
@@ -3350,8 +3621,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -3391,9 +3661,9 @@
       }
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true
     },
     "typed-rest-client": {
@@ -3609,7 +3879,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -3618,8 +3887,7 @@
     "xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -3634,13 +3902,21 @@
       "dev": true
     },
     "yargs-parser": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "zip-stream": {

--- a/tasks/DependencyCheck/task/package.json
+++ b/tasks/DependencyCheck/task/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@azure/storage-blob": "^12.1.2",
     "@types/node-emoji": "^1.8.1",
     "@types/q": "^1.5.2",
     "@types/request": "^2.48.4",

--- a/tasks/DependencyCheck/task/task.json
+++ b/tasks/DependencyCheck/task/task.json
@@ -3,7 +3,7 @@
   "id": "93ee1ebd-95c1-485e-bad4-5514e88f6c62",
   "name": "DependencyCheck",
   "friendlyName": "Dependency Check",
-  "description": "OWASP Dependency Check task for Azure Pipelines",
+  "description": "Dependency Check task for Azure Pipelines to identify vulnerable third-party components",
   "helpMarkDown": "",
   "category": "Utility",
   "author": "esfadevops",
@@ -15,12 +15,30 @@
   "instanceNameFormat": "Dependency Check",
   "inputs": [
     {
+      "name": "enableVulnerabilityFilesMaintenance",
+      "type": "boolean",
+      "label": "Enable maintenance of vulnerability files in storage account",
+      "defaultValue": "false",
+      "required": true,
+      "helpMarkDown": "Select to enable maintenance of vulnerability files in storage account."
+    },
+    {
+      "name": "writeStorageAccountContainerSasUri",
+      "type": "string",
+      "label": "Write Shared Access Signature Uri for storage account blob container",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Write Shared Access Signature Uri for blob container of storage account to update the versioned vulnerability files: odc.mv.db and jsrepository.json",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = true"
+    },
+    {
       "name": "workspaceId",
       "type": "string",
       "label": "Workspace Id",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "A Log Analytics workspace Id"
+      "helpMarkDown": "A Log Analytics workspace Id",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = false"
     },
     {
       "name": "sharedKey",
@@ -28,24 +46,26 @@
       "label": "Shared Key",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "A Log Analytics workspace shared key"
+      "helpMarkDown": "A Log Analytics workspace shared key",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = false"
     },
     {
-      "name": "enableSelfHostedDatabase",
+      "name": "enableSelfHostedVulnerabilityFiles",
       "type": "boolean",
-      "label": "Enable self hosted database",
+      "label": "Enable self hosted vulnerability files",
       "defaultValue": "false",
-      "helpMarkDown": "Select to enable self hosted database of vulnerabilities for this task.",
-      "required": true
+      "required": true,
+      "helpMarkDown": "Select to enable self hosted vulnerability files.",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = false"
     },
     {
-      "name": "databaseEndpoint",
+      "name": "readStorageAccountContainerSasUri",
       "type": "string",
-      "label": "Database endpoint",
+      "label": "Read Shared Access Signature Uri to download the database of vulnerabilities",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Database endpoint that has files odc.mv.db and jsrepository.json, eg. https://<storage account name>.blob.core.windows.net/<blob container name>",
-      "visibleRule": "enableSelfHostedDatabase = true"
+      "helpMarkDown": "Read Shared Access Signature Uri for for blob container of storage account to download the versioned vulnerability files: odc.mv.db and jsrepository.json",
+      "visibleRule": "enableSelfHostedVulnerabilityFiles = true"
     },
     {
       "name": "scanPath",
@@ -53,7 +73,8 @@
       "label": "Scan path",
       "defaultValue": "$(Agent.BuildDirectory)",
       "required": true,
-      "helpMarkDown": "Path to scan for vulnerabiities"
+      "helpMarkDown": "Path to scan for vulnerabiities",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = false"
     },
     {
       "name": "excludedScanPathPatterns",
@@ -61,7 +82,8 @@
       "label": "Excluded scan path patterns",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Path patterns to exclude from scan for vulnerabiities"
+      "helpMarkDown": "Path patterns to exclude from scan for vulnerabiities",
+      "visibleRule": "enableVulnerabilityFilesMaintenance = false"
     }
   ],
   "execution": {

--- a/tasks/DependencyCheck/task/tests/TaskRunner.ts
+++ b/tasks/DependencyCheck/task/tests/TaskRunner.ts
@@ -2,10 +2,12 @@ import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
 const inputs = [
+  'enableVulnerabilityFilesMaintenance',
+  'writeStorageAccountContainerSasUri',
   'workspaceId',
   'sharedKey',
-  'enableSelfHostedDatabase',
-  'databaseEndpoint',
+  'enableSelfHostedVulnerabilityFiles',
+  'readStorageAccountContainerSasUri',
   'scanPath',
   'excludedScanPathPatterns',
 ];

--- a/tasks/DependencyCheck/task/utility.ts
+++ b/tasks/DependencyCheck/task/utility.ts
@@ -5,6 +5,7 @@ import emoji = require('node-emoji');
 import tl = require('azure-pipelines-task-lib/task');
 import http = require('https');
 import path = require('path');
+import { ContainerClient, AnonymousCredential } from "@azure/storage-blob";
 
 export function cleanDependencyCheckData(): void {
   const p = path.join(__dirname, 'dependency-check-cli', 'data');
@@ -12,41 +13,64 @@ export function cleanDependencyCheckData(): void {
     tl.checkPath(p, 'Dependency check cli data folder');
     tl.rmRF(p);
   } catch (e) {
-    tl.debug(`An error was caugh during cleanup ${e}`);
+    tl.debug(`An error was caught during cleanup ${e}`);
     tl.warning(`Data path did not exist. The task will attempt to create it at: ${p}`);
   }
 
   tl.mkdirP(p);
 }
 
-export async function getVulnData(databaseEndpoint: string, blobName: string, filePath: string): Promise<void> {
+export async function downloadVulnData(readStorageAccountContainerSasUri: string, filePath: string, taskVersion: string): Promise<void> {
   const file = fs.createWriteStream(filePath);
-  const vulnUrl = `${databaseEndpoint}/${blobName}`;
+  const anonymousCredential = new AnonymousCredential();
+  const blobServiceClient = new ContainerClient(
+    `${readStorageAccountContainerSasUri}`,
+    anonymousCredential
+  );
+  const blobName = `${taskVersion}/${path.basename(filePath)}`;
+  const blockBlobClient = blobServiceClient.getBlockBlobClient(blobName);
   return new Promise<void>((resolve, reject) => {
-    http.get(vulnUrl, (response: any) => {
-      response.pipe(file);
-      console.log(`${emoji.get('timer_clock')}  Downloading file [${vulnUrl}]`);
-      file.on('finish', () => {
-        file.close();
-        console.log(`${emoji.get('heavy_check_mark')}  File download complete!`);
-        resolve();
-      });
-
-      file.on('error', (err) => {
-        fs.unlink(filePath, () => { });
-        reject(new Error(err));
-      });
-    });
+    try {
+      blockBlobClient.downloadToFile(filePath)
+        .then(() => console.log(`Successful download of vulnerability data file ${blobName}`))
+        .catch((e) => reject(new Error(`Download of vulnerability data file ${blobName} failed with error code: ${e.message}`)))
+        .finally(resolve)
+    }
+    catch (e) {
+      reject(new Error(`Download of vulnerability data file ${blobName} failed with error code: ${e.message}`));
+    }
   });
 }
 
-export async function owaspCheck(scriptPath: string, scanPath: string, excludedScanPathPatterns: string, resultsPath: string, enableSelfHostedDatabase: boolean): Promise<string> {
+export async function UploadVulnData(writeStorageAccountContainerSasUri: string, filePath: string, taskVersion: string): Promise<void> {
+  const anonymousCredential = new AnonymousCredential();
+  const blobServiceClient = new ContainerClient(
+    `${writeStorageAccountContainerSasUri}`,
+    anonymousCredential
+  );
+  const file = fs.readFileSync(filePath);
+  const blobName = `${taskVersion}/${path.basename(filePath)}`;
+  const blockBlobClient = blobServiceClient.getBlockBlobClient(blobName);
+  return new Promise<void>((resolve, reject) => {
+    try {
+      blockBlobClient.upload(file, Buffer.byteLength(file))
+        .then(() => console.log(`Successful upload of vulnerability data file ${blobName}`))
+        .catch((e) => reject(new Error(`Failed upload of vulnerability data file ${blobName} with error code: ${e.message}`)))
+        .finally(resolve)
+    }
+    catch (e) {
+      reject(new Error(`Upload of vulnerability data file ${blobName} failed with error code: ${e.message}`));
+    }
+  });
+}
+
+export async function owaspCheck(scriptPath: string, scanPath: string, excludedScanPathPatterns: string, resultsPath: string, enableSelfHostedVulnerabilityFiles: boolean): Promise<string> {
   const projectName = 'OWASP Dependency Check';
   const format = 'CSV';
   tl.debug(`OWASP scan directory set to ${scanPath}`);
   // Log warning if new version of dependency-check CLI is available
 
-  const args = enableSelfHostedDatabase ? ['--project', projectName, '--scan', scanPath, '--exclude', excludedScanPathPatterns, '--out', resultsPath, '--format', format, '--noupdate'] :
+  const args = enableSelfHostedVulnerabilityFiles ? ['--project', projectName, '--scan', scanPath, '--exclude', excludedScanPathPatterns, '--out', resultsPath, '--format', format, '--noupdate'] :
     ['--project', projectName, '--scan', scanPath, '--exclude', excludedScanPathPatterns, '--out', resultsPath, '--format', format]
 
   console.log(`${emoji.get('lightning')}  Executing dependency-check-cli.`);


### PR DESCRIPTION
Task to now use automatically updated versioned vulnerability files in private blob container with new task parameter enableVulnerabilityFilesMaintenance option to maintain the files.

If enableVulnerabilityFilesMaintenance is true, vulnerability files (jsrepository.json and odc.mv.db) in the storage account blob container will be created/overwritten in a folder with name of the task version, using the new parameter writeStorageAccountContainerSasUri.

enableSelfHostedDatabase parameter renamed to enableSelfHostedVulnerabilityFiles.

databaseEndpoint parameter replaced with readStorageAccountContainerSasUri.

The azure-pipelines.yml will write the new versioned files if master branch by running 'npm test'