### PR TITLE
Dependency Check: Additional referencing of global variables +semver: patch

### DIFF
--- a/tasks/DependencyCheck/azure-pipelines.yml
+++ b/tasks/DependencyCheck/azure-pipelines.yml
@@ -84,7 +84,7 @@ steps:
    $Path = "$(System.DefaultWorkingDirectory)/tasks/DependencyCheck/task"
    $Value = @"
    enableVulnerabilityFilesMaintenance=true
-   writeStorageAccountContainerSasUri=https://$(SharedStorageAccountName).$($ENV:StorageAccountService).core.windows.net/$($ENV:StorageAccountContainerName)$($ENV:WRITE_STORAGE_ACCOUNT_CONTAINER_SAS_URI)
+   writeStorageAccountContainerSasUri=https://$(SharedStorageAccountName).$(StorageAccountService).core.windows.net/$(StorageAccountContainerName)$($ENV:WRITE_STORAGE_ACCOUNT_CONTAINER_SAS_URI)
    logAnalyticsWorkspaceId=placeholder
    logAnalyticsWorkspaceKey=placeholder
    enableSelfHostedVulnerabilityFiles=placeholder


### PR DESCRIPTION
Corrected referencing of additional variables in inline powershell script to be global variables

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-variables-in-pipeline